### PR TITLE
Do not try to update the state configmap when no state file was produced

### DIFF
--- a/terraform.sh
+++ b/terraform.sh
@@ -14,26 +14,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DIR_STATE_CONFIG_MAP="/tf-state-in"
+DIR_STATE_IN="/tf-state-copy"
+DIR_STATE_OUT="/tf-state-out"
+DIR_VARIABLES="/tfvars"
+DIR_PROVIDERS="/terraform-providers"
+
+PATH_STATE_CONFIG_MAP="$PATH_STATE_CONFIG_MAP"
+PATH_STATE_IN="$DIR_STATE_IN/terraform.tfstate"
+PATH_STATE_OUT="$DIR_STATE_OUT/terraform.tfstate"
+PATH_VARIABLES="$DIR_VARIABLES/terraform.tfvars"
+
+PATH_CACERT="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+NAMESPACE"$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)"
+TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+BASE_URL="https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT_HTTPS"
+
 # determine command
 command="${1:-apply}"
 exitcode=1
 
-mkdir /tf-state-out
+mkdir -p "$DIR_STATE_IN"
+mkdir -p "$DIR_STATE_OUT"
 
 # required to initialize the AWS provider plugin (since v0.10.0, see https://www.terraform.io/upgrade-guides/0-10.html)
-terraform init -plugin-dir=/terraform-providers /tf
+terraform init -plugin-dir="$DIR_PROVIDERS" /tf
 # workaround for `terraform init`; required to make `terraform validate` work (plugin_path file ignored?)
-cp -r /terraform-providers/* .terraform/plugins/linux_amd64/.
+cp -r "$DIR_PROVIDERS"/* .terraform/plugins/linux_amd64/.
 # copy input terraform state into another directory because it's mounted as configmap (read-only filesystem) and terraform will try to write onto that fs
-mkdir -p /tf-state-tmp
-cp /tf-state-in/* /tf-state-tmp
+cp "$DIR_STATE_CONFIG_MAP"/* "$DIR_STATE_IN"
 
 function end_execution() {
   # Delete trap handler to avoid recursion
   trap - HUP QUIT PIPE INT TERM EXIT
 
   # check whether the terraform state has changed
-  if diff /tf-state-tmp/terraform.tfstate /tf-state-out/terraform.tfstate 1> /dev/null; then # passes (returns 0) if there is no diff
+  if [[ ! -f "$PATH_STATE_OUT" ]] || diff "$PATH_STATE_IN" "$PATH_STATE_OUT" 1> /dev/null; then # passes (returns 0) if there is no diff
     # indicate success (exit code gets lost as the surrounding command pipes this script through 'tee')
     echo -e "\nNothing to do."
     if [[ $exitcode -eq 0 ]]; then
@@ -42,27 +58,28 @@ function end_execution() {
     exit 0
   else
     # update config map with the new terraform state (see https://stackoverflow.com/questions/30690186/how-do-i-access-the-kubernetes-api-from-within-a-pod-container)
-    echo -e "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: $TF_STATE_CONFIG_MAP_NAME\ndata:\n  terraform.tfstate: |" > /tf-state-out/$TF_STATE_CONFIG_MAP_NAME
-    cat /tf-state-out/terraform.tfstate | sed -n 's/^/    /gp' >> /tf-state-out/$TF_STATE_CONFIG_MAP_NAME
+    echo -e "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: $TF_STATE_CONFIG_MAP_NAME\ndata:\n  terraform.tfstate: |" > "$PATH_STATE_CONFIG_MAP"
+    cat "$PATH_STATE_OUT" | sed -n 's/^/    /gp' >> "$PATH_STATE_CONFIG_MAP"
     curl \
       --silent \
-      --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-      --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+      --cacert "$PATH_CACERT" \
+      --header "Authorization: Bearer $TOKEN" \
       --header "Content-Type: application/yaml" \
       --request PUT \
-      --data-binary @/tf-state-out/$TF_STATE_CONFIG_MAP_NAME \
-      https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT_HTTPS/api/v1/namespaces/$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)/configmaps/$TF_STATE_CONFIG_MAP_NAME > /dev/null
+      --data-binary @"$PATH_STATE_CONFIG_MAP" \
+      "$BASE_URL/api/v1/namespaces/$NAMESPACE/configmaps/$TF_STATE_CONFIG_MAP_NAME" > /dev/null
 
     # validate that the current terraform state is properly reflected in the config map
     curl \
       --silent \
-      --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-      --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+      --cacert "$PATH_CACERT" \
+      --header "Authorization: Bearer $TOKEN" \
       --header "Accept: application/yaml" \
-      --request GET https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT_HTTPS/api/v1/namespaces/$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)/configmaps/$TF_STATE_CONFIG_MAP_NAME > /tf-state-out/$TF_STATE_CONFIG_MAP_NAME.put
+      --request GET \
+      "$BASE_URL/api/v1/namespaces/$NAMESPACE/configmaps/$TF_STATE_CONFIG_MAP_NAME" > "$PATH_STATE_CONFIG_MAP.put"
 
-    sed -i -n 's/^    //gp' /tf-state-out/$TF_STATE_CONFIG_MAP_NAME.put
-    if diff /tf-state-out/terraform.tfstate /tf-state-out/$TF_STATE_CONFIG_MAP_NAME.put 1> /dev/null; then # passes (returns 0) if there is no diff
+    sed -i -n 's/^    //gp' "$DIR_STATE_OUT/$TF_STATE_CONFIG_MAP_NAME.put"
+    if diff "$PATH_STATE_OUT" "$DIR_STATE_OUT/$TF_STATE_CONFIG_MAP_NAME.put" 1> /dev/null; then # passes (returns 0) if there is no diff
       # indicate success (exit code gets lost as the surrounding command pipes this script through 'tee')
       echo -e "\nConfigMap successfully updated with terraform state."
       if [[ $exitcode -eq 0 ]]; then
@@ -72,7 +89,7 @@ function end_execution() {
     else
       # dump terraform state so that we can find it at least in the logs
       echo -e "\nConfigMap could not be updated with terraform state! Dumping state file now to have it in the logs:"
-      cat /tf-state-out/terraform.tfstate
+      cat "$PATH_STATE_OUT"
       exit 1
     fi
   fi
@@ -82,15 +99,15 @@ if [[ "$command" == "validate" ]]; then
   terraform \
     validate \
     -check-variables=true \
-    -var-file=/tfvars/terraform.tfvars \
+    -var-file="$PATH_VARIABLES" \
     /tf
   if [[ "$?" == "0" ]]; then
     terraform \
       plan \
       -parallelism=4 \
       -detailed-exitcode \
-      -state=/tf-state-tmp/terraform.tfstate \
-      -var-file=/tfvars/terraform.tfvars \
+      -state="$PATH_STATE_IN" \
+      -var-file="$PATH_VARIABLES" \
       /tf
   else
     exit $?
@@ -104,9 +121,9 @@ else
       apply \
       -auto-approve \
       -parallelism=4 \
-      -state=/tf-state-tmp/terraform.tfstate \
-      -state-out=/tf-state-out/terraform.tfstate \
-      -var-file=/tfvars/terraform.tfvars \
+      -state="$PATH_STATE_IN" \
+      -state-out="$PATH_STATE_OUT" \
+      -var-file="$PATH_VARIABLES" \
       /tf
     exitcode=$?
   elif [[ "$command" == "destroy" ]]; then
@@ -114,9 +131,9 @@ else
       destroy \
       -force \
       -parallelism=4 \
-      -state=/tf-state-tmp/terraform.tfstate \
-      -state-out=/tf-state-out/terraform.tfstate \
-      -var-file=/tfvars/terraform.tfvars \
+      -state="$PATH_STATE_IN" \
+      -state-out="$PATH_STATE_OUT" \
+      -var-file="$PATH_VARIABLES" \
       /tf
     exitcode=$?
   else


### PR DESCRIPTION
So far, when Terraform did not produce a state file at all after running `terraform apply`, we have updated the ConfigMap storing the state and replaced the existing value with an empty string.

This commit
- introduces variables to often used paths
- prevents updates to the ConfigMap when no state file was produced after `terraform apply`.