### PR TITLE
Set alicloud provider version to 1.22.0

### DIFF
--- a/terraform-bundle.hcl
+++ b/terraform-bundle.hcl
@@ -21,7 +21,7 @@ providers {
   azurerm   = ["1.4.0"]
   google    = ["1.12.0"]
   openstack = ["1.4.0"]
-  alicloud  = ["1.10.0"]
+  alicloud  = ["1.22.0"]
   template  = ["1.0.0"]
   null      = ["1.0.0"]
 }


### PR DESCRIPTION
Hi, 

New version of alicloud provider fixed some bugs. 

```improvement user
The `alicloud` Terraform provider plugin has been upgraded from `1.10.0` to `1.22.0`.
```