### PR TITLE
Prepration for upgrade to terraform 0.12

### DIFF
--- a/terraform-bundle.hcl
+++ b/terraform-bundle.hcl
@@ -17,12 +17,12 @@ terraform {
 }
 
 providers {
-  aws       = ["1.60.0"]
-  azurerm   = ["1.22.1"]
-  google    = ["1.20.0"]
-  openstack = ["1.16.0"]
-  alicloud  = ["1.31.0"]
-  packet    = ["1.7.2"]
+  aws       = ["2.26.0"]
+  azurerm   = ["1.33.1"]
+  google    = ["2.14.0"]
+  openstack = ["1.21.1"]
+  alicloud  = ["1.55.2"]
+  packet    = ["2.3.0"]
   template  = ["1.0.0"]
   null      = ["1.0.0"]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Terraform released 0.12 quite a while ago. 

As a first step to upgrade to terraform 0.12 all providers must be upgraded to support the new terraform version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
Provider versions are upgraded:

- aws `1.60.0` -> `2.26.0`
- google `1.20.0` -> `2.14.0`
- azurerm `1.22.1` -> `1.33.1`
- openstack `1.16.0` -> `1.21.1`
- alicloud `1.31.0` -> `1.55.2`
- packet `1.7.2` -> `2.3.0`
```
