### PR TITLE
Add google beta provider

### DIFF
--- a/terraform-bundle.hcl
+++ b/terraform-bundle.hcl
@@ -20,6 +20,7 @@ providers {
   aws       = ["2.26.0"]
   azurerm   = ["1.33.1"]
   google    = ["2.14.0"]
+  google-beta = ["2.14.0"]
   openstack = ["1.21.1"]
   alicloud  = ["1.55.2"]
   packet    = ["2.3.0"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Add google beta provider to enable gcp beta ressources in terraform.
Required for enabling VPC Flow logs on GCP.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Added google beta provider 
```
