### PR TITLE
Update template and null providers for terraform v0.12

### DIFF
--- a/terraform-bundle.hcl
+++ b/terraform-bundle.hcl
@@ -17,13 +17,13 @@ terraform {
 }
 
 providers {
-  aws       = ["2.26.0"]
-  azurerm   = ["1.33.1"]
-  google    = ["2.14.0"]
+  aws         = ["2.26.0"]
+  azurerm     = ["1.33.1"]
+  google      = ["2.14.0"]
   google-beta = ["2.14.0"]
-  openstack = ["1.21.1"]
-  alicloud  = ["1.55.2"]
-  packet    = ["2.3.0"]
-  template  = ["1.0.0"]
-  null      = ["1.0.0"]
+  openstack   = ["1.21.1"]
+  alicloud    = ["1.55.2"]
+  packet      = ["2.3.0"]
+  template    = ["2.1.2"]
+  null        = ["2.1.2"]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
`template` and `null` providers also need to be updated for terraform v0.12.
Ref https://github.com/terraform-providers/terraform-provider-template/blob/master/CHANGELOG.md and https://github.com/terraform-providers/terraform-provider-null/blob/master/CHANGELOG.md.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Provider versions are upgraded:

- template `1.0.0` -> `2.1.2`
- null `1.0.0` -> `2.1.2`
```
