### PR TITLE
Update google provider to 3.4.0

### DIFF
--- a/terraform-bundle.hcl
+++ b/terraform-bundle.hcl
@@ -19,8 +19,8 @@ terraform {
 providers {
   aws         = ["2.26.0"]
   azurerm     = ["1.33.1"]
-  google      = ["2.14.0"]
-  google-beta = ["2.14.0"]
+  google      = ["3.4.0"]
+  google-beta = ["3.4.0"]
   openstack   = ["1.21.1"]
   alicloud    = ["1.55.2"]
   packet      = ["2.3.0"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Update google provider to support block type log_config.
Required for enabling vpc flow logs on gardener.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
none
```
