### PR TITLE
Update azurerm provider to support natgateway

### DIFF
--- a/terraform-bundle.hcl
+++ b/terraform-bundle.hcl
@@ -18,7 +18,7 @@ terraform {
 
 providers {
   aws         = ["2.26.0"]
-  azurerm     = ["1.33.1"]
+  azurerm     = ["1.44.0"]
   google      = ["3.4.0"]
   google-beta = ["3.4.0"]
   openstack   = ["1.21.1"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Need to bump the `azurerm` to a version which support the Azure NatGateway.

There seems to be a bug, which affect the Azure Nat Gateway integration. See here: https://github.com/terraform-providers/terraform-provider-azurerm/issues/6052

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Update Terraform `azurerm` provider to support Azure NatGateway.
```
