### PR TITLE
Gracefully shutdown the terraform process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,6 @@ COPY --from=builder /tmp/terraformer/terraform /bin/terraform
 COPY --from=builder /tmp/terraformer/terraform-provider* /terraform-providers/
 
 ADD ./terraform.sh /terraform.sh
+ADD ./terraformer.sh /terraformer.sh
 
-CMD exec /terraform.sh
+CMD exec /terraformer.sh

--- a/example/20-terraformer-validate-pod.yaml
+++ b/example/20-terraformer-validate-pod.yaml
@@ -25,9 +25,8 @@ spec:
     image: eu.gcr.io/gardener-project/gardener/terraformer:latest
     imagePullPolicy: IfNotPresent
     command:
-    - sh
-    - -c
-    - sh /terraform.sh validate
+    - /terraformer.sh
+    - validate
     env:
     - name: TF_STATE_CONFIG_MAP_NAME
       value: some-name.infra.tf-state

--- a/example/30-terraformer-apply-pod.yaml
+++ b/example/30-terraformer-apply-pod.yaml
@@ -25,9 +25,8 @@ spec:
     image: eu.gcr.io/gardener-project/gardener/terraformer:latest
     imagePullPolicy: IfNotPresent
     command:
-    - sh
-    - -c
-    - sh /terraform.sh apply 2>&1; [[ -f /success ]] && exit 0 || exit 1
+    - /terraformer.sh
+    - apply
     env:
     - name: TF_STATE_CONFIG_MAP_NAME
       value: some-name.infra.tf-state

--- a/example/40-terraformer-destroy-pod.yaml
+++ b/example/40-terraformer-destroy-pod.yaml
@@ -25,9 +25,8 @@ spec:
     image: eu.gcr.io/gardener-project/gardener/terraformer:0.16.0
     imagePullPolicy: IfNotPresent
     command:
-    - sh
-    - -c
-    - sh /terraform.sh destroy 2>&1; [[ -f /success ]] && exit 0 || exit 1
+    - /terraformer.sh
+    - destroy
     env:
     - name: TF_STATE_CONFIG_MAP_NAME
       value: some-name.infra.tf-state

--- a/terraformer.sh
+++ b/terraformer.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -u
+#
+# Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function end_execution() {
+  # Delete trap handler to avoid recursion
+  trap - HUP QUIT PIPE INT TERM
+
+  if [ -n "$PID" ] && kill -0 "$PID" &>/dev/null; then
+    echo "$(date) Sending SIGTERM to terraform.sh process $PID."
+    kill -SIGTERM $PID
+    echo "$(date) Waiting for terraform.sh process $PID to complete..."
+    wait $PID
+    echo "$(date) terraform.sh process $PID completed."
+  fi
+}
+
+# determine command
+command="${1:-apply}"
+
+trap end_execution INT TERM
+
+PID=
+
+/terraform.sh "$command" 2>&1 &
+PID=$!
+wait $PID
+exitcode=$?
+
+echo "$(date) terraform.sh exited with $exitcode."
+
+[[ -f /success ]] && exit 0 || exit 1


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently signals sent to PID 1 in the terraformer image are not forwarded to the child processes as PID 1 is `sh`. This prevents the terraform process itself to receive a SIGTERM and start graceful termination. After a `terminationGracePeriodSeconds`, the terraformer Pod can be SIGKILL-ed and the terraform process itself can lose its current terraform.tfstate.


This PR:
- introduces a wrapper `terraformer.sh` process which runs as PID 1 and sends SIGTERM to the running child `terraform.sh` process (if any) on termination and waits for its completion
- modifies `terraform.sh` to sent SIGTERM to the running terraform process  (if any) on termination and waits for its completion. On the other side, if the current command is `apply`, terraform stops creating new resources and waits only for the creation of the resources which were already in creating when the SIGTERM was sent.


**Which issue(s) this PR fixes**:
Ref gardener/gardener-extensions#597

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
`terraformer` does no longer ignore the termination signals sent to PID 1. It does now send a termination signal to the terraform process itself and waits for its completion. This should prevent rare cases in which the `terraformer` was not storing the state of created infrastructure resources.
```
