### PR TITLE
Bump OpenStack provider to v1.28.0

### DIFF
--- a/terraform-bundle.hcl
+++ b/terraform-bundle.hcl
@@ -21,7 +21,7 @@ providers {
   azurerm     = ["1.44.0"]
   google      = ["3.4.0"]
   google-beta = ["3.4.0"]
-  openstack   = ["1.21.1"]
+  openstack   = ["1.28.0"]
   alicloud    = ["1.84.0"]
   packet      = ["2.3.0"]
   template    = ["2.1.2"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump OpenStack provider to `v1.28.0`.

We need this fix included https://github.com/terraform-providers/terraform-provider-openstack/pull/628 to unblock this PR https://github.com/gardener/gardener-extension-provider-openstack/pull/92
I basically bumped to the most recent version of the provider.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The OpenStack terraform provider is now used in version v1.28.0.
```
