### PR TITLE
Update aws and google provider versions

### DIFF
--- a/terraform-bundle.hcl
+++ b/terraform-bundle.hcl
@@ -17,10 +17,10 @@ terraform {
 }
 
 providers {
-  aws         = ["2.26.0"]
+  aws         = ["2.68.0"]
   azurerm     = ["1.44.0"]
-  google      = ["3.4.0"]
-  google-beta = ["3.4.0"]
+  google      = ["3.27.0"]
+  google-beta = ["3.27.0"]
   openstack   = ["1.28.0"]
   alicloud    = ["1.84.0"]
   packet      = ["2.3.0"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Update aws and google provider versions.


**Special notes for your reviewer**:
I decided to start small and postpone the tf version and provider azurerm version updates for a future terraformer release:
- we recently updated the tf version but not to the latest one. However tf version cannot be downgraded/rolled back and probably it is not a good idea to combine it with multiple provider version bumps in a single terraformer release.
- azurerm has a new major release and we will need small adaptations in our `main.tf` (I didn't play with it yet).



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
`terraform-provider-aws` is now updated to `2.68.0`.
```

```improvement operator
`terraform-provider-google` and `terraform-provider-google-beta` are now updated to `3.27.0`.
```