### PR TITLE
Adapt example manifests to terraform 0.12

### DIFF
--- a/example/10-config.yaml
+++ b/example/10-config.yaml
@@ -21,9 +21,9 @@ metadata:
 data:
   main.tf: |
     provider "aws" {
-      access_key = "${var.ACCESS_KEY_ID}"
-      secret_key = "${var.SECRET_ACCESS_KEY}"
-      region     = "us-east-1"
+      access_key = var.ACCESS_KEY_ID
+      secret_key = var.SECRET_ACCESS_KEY
+      region     = "eu-central-1"
     }
 
     resource "aws_route53_record" "www" {
@@ -35,13 +35,13 @@ data:
     }
   variables.tf: |
     variable "ACCESS_KEY_ID" {
-      description = "AWS Access Key ID"
-      type        = "string"
+      description = "AWS Access Key ID of technical user"
+      type        = string
     }
 
     variable "SECRET_ACCESS_KEY" {
-      description = "AWS Secret Access Key"
-      type        = "string"
+      description = "AWS Secret Access Key of technical user"
+      type        = string
     }
 
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
/area dev-productivity
/kind cleanup

Following up on #27, this PR adapts the example manifests to language changes in terraform 0.12

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @ialidzhikov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
