### PR TITLE
Do not overwrite existing files during unzip

### DIFF
--- a/scripts/fetch-providers
+++ b/scripts/fetch-providers
@@ -21,4 +21,4 @@ terraform-bundle \
   <(cat $(dirname $0)/../terraform-bundle.hcl | sed "s/TF_VERSION/$(cat "$(dirname $0)/../TF_VERSION")/g")
 
 BUNDLE="$(ls -t terraform*.zip | head -1)"
-unzip $BUNDLE
+unzip -n $BUNDLE


### PR DESCRIPTION
**What this PR does / why we need it**:
Staring from v1.92.0 provider-alicloud plugin packages not only the plugin binary, but also the `CHANGELOG.md`, `LICENSE`, `README.md` files.

```
$ wget https://releases.hashicorp.com/terraform-provider-alicloud/1.94.0/terraform-provider-alicloud_1.94.0_linux_amd64.zip

$ unzip terraform-provider-alicloud_1.94.0_linux_amd64.zip
Archive:  terraform-provider-alicloud_1.94.0_linux_amd64.zip
  inflating: CHANGELOG.md
  inflating: LICENSE
  inflating: README.md
  inflating: terraform-provider-alicloud_v1.94.0 
```

 Trying to bump our provider-alicloud version in https://github.com/gardener/terraformer/pull/45, fails with:

```
Creating terraform_0.12.20-bundle2020083107_linux_amd64.zip ...
All done!
Archive:  terraform_0.12.20-bundle2020083107_linux_amd64.zip
  inflating: CHANGELOG.md            
  inflating: LICENSE                 
replace README.md? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
(EOF or read error, treating as "[N]one" ...)
  inflating: terraform               
  inflating: terraform-provider-alicloud_v1.94.0  
  inflating: terraform-provider-aws_v2.68.0_x4  
  inflating: terraform-provider-azurerm_v1.44.0_x4  
  inflating: terraform-provider-google-beta_v3.27.0_x5  
  inflating: terraform-provider-google_v3.27.0_x5  
  inflating: terraform-provider-null_v2.1.2_x4  
  inflating: terraform-provider-openstack_v1.28.0_x4  
  inflating: terraform-provider-packet_v2.3.0_x4  
  inflating: terraform-provider-template_v2.1.2_x4  
The command '/bin/sh -c export TF_VERSION=$(cat /tmp/terraformer/TF_VERSION) &&     export KUBECTL_VERSION=$(cat /tmp/terraformer/KUBECTL_VERSION) &&     apt-get update &&     apt-get install -y unzip &&     mkdir -p /go/src/github.com/hashicorp &&     git clone --single-branch --depth 1 --branch v${TF_VERSION} https://github.com/hashicorp/terraform.git /go/src/github.com/hashicorp/terraform &&     cd /go/src/github.com/hashicorp/terraform &&     go install ./tools/terraform-bundle &&     cd /tmp/terraformer &&     ./scripts/fetch-providers &&     curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl &&     chmod +x ./kubectl' returned a non-zero code: 1
```

With `unzip -n` we can instruct unzip to do not ask for input (and to do not overwrite existing file) in case of conflict.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
