### PR TITLE
Fix injected build version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY --from=base /tmp/terraformer/terraform /bin/terraform
 COPY --from=base /tmp/terraformer/terraform-provider* /terraform-providers/
 COPY --from=builder /go/bin/terraformer /
 
-ENTRYPOINT /terraformer
+ENTRYPOINT ["/terraformer"]
 
 #############      dev           #############
 FROM golang-base AS dev

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,9 @@ IMAGE_REPOSITORY     := eu.gcr.io/gardener-project/gardener/$(NAME)
 IMAGE_REPOSITORY_DEV := $(IMAGE_REPOSITORY)/dev
 REPO_ROOT            := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 VERSION              := $(shell cat "$(REPO_ROOT)/VERSION")
-EFFECTIVE_VERSION    := $(VERSION)-$(shell git rev-parse HEAD)
 
-ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
-	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
+ifeq ($(EFFECTIVE_VERSION),)
+	EFFECTIVE_VERSION := $(shell $(REPO_ROOT)/hack/get-version.sh)
 endif
 
 IMAGE_TAG            := $(EFFECTIVE_VERSION)
@@ -23,6 +22,7 @@ LD_FLAGS             := "-w -X github.com/gardener/$(NAME)/pkg/version.Version=$
 COMMAND       := apply
 ZAP_DEVEL     := true
 ZAP_LOG_LEVEL := debug
+
 .PHONY: run
 run:
 	# running `go run ./cmd/terraformer $(COMMAND)`

--- a/hack/get-version.sh
+++ b/hack/get-version.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+#
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+VERSION="$(cat "$(dirname $0)/../VERSION")"
+
+if [[ "$VERSION" = *-dev ]] ; then
+  VERSION="$VERSION-$(git rev-parse HEAD)"
+fi
+
+# .dockerignore ignores all files unrelevant for build (e.g. docs) to only copy relevant source files to the build
+# container. Hence, git will always detect a dirty work tree when building in a container (many deleted files).
+# This command filters out all deleted files that are ignored by .dockerignore to only detect changes to relevant files
+# as a dirty work tree.
+# Additionally, it filters out changes to the `VERSION` file, as this is currently the only way to inject the
+# version-to-build in our pipelines (see https://github.com/gardener/cc-utils/issues/431).
+TREE_STATE="$([ -z "$(git status --porcelain 2>/dev/null | grep -vf <(git ls-files --deleted --ignored --exclude-from=.dockerignore) -e 'VERSION')" ] && echo clean || echo dirty)"
+
+if [ "$TREE_STATE" = dirty ] ; then
+  VERSION="$VERSION-dirty"
+fi
+
+echo "$VERSION"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR 
- fixes the docker entrypoint, so that commands can be run properly, e.g. `docker run TERRAFORMER_IMAGE apply` works now
- fixes the injected build version in pipeline runs:

before:
```
$ docker run eu.gcr.io/gardener-project/gardener/terraformer:v2.0.0-dev-eb81a7c84204e9746e2f86da47885c9311418446
{"level":"info","ts":"2020-11-16T12:09:34.796Z","msg":"Starting terraformer...","version":"v2.0.0-dev-eb81a7c84204e9746e2f86da47885c9311418446-eb81a7c84204e9746e2f86da47885c9311418446-dirty"}
...
```
after:
```
$ docker run eu.gcr.io/gardener-project/gardener/terraformer:v2.0.0-dev-ab2df864675414cc06537878fb8b6cd3e152b0c0
{"level":"info","ts":"2020-11-16T17:35:42.677Z","msg":"Starting terraformer...","version":"v2.0.0-dev-ab2df864675414cc06537878fb8b6cd3e152b0c0"}
...
```

**Which issue(s) this PR fixes**:
Part of #40 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
