### PR TITLE
Update azurerm provider to v2.36.0 (major version upgrade)

### DIFF
--- a/terraform-bundle.hcl
+++ b/terraform-bundle.hcl
@@ -18,7 +18,7 @@ terraform {
 
 providers {
   aws         = ["2.68.0"]
-  azurerm     = ["1.44.0"]
+  azurerm     = ["2.36.0"]
   google      = ["3.27.0"]
   google-beta = ["3.27.0"]
   openstack   = ["1.28.0"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade the `azurerm` provider to `v2.36.0` (major version upgrade).

**Special notes for your reviewer**:
There is some migration logic required in the respective provider extension, see here: 

Let's wait until referenced PR is reviewed and approved before we merge this one.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Terraformer uses now the azurerm provider in version v2.36.0
```
