### PR TITLE
Update base image to workaround dockerhub rate limit issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.15.3 AS builder
+FROM eu.gcr.io/gardener-project/3rd/golang:1.15.3 AS builder
 
 WORKDIR /tmp/terraformer
 COPY . .


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
