### PR TITLE
Fix release test config/script

### DIFF
--- a/.ci/test-e2e.sh
+++ b/.ci/test-e2e.sh
@@ -10,6 +10,8 @@ mkdir -p /tm
 /cc/utils/cli.py config attribute --cfg-type kubernetes --cfg-name testmachinery --key kubeconfig > /tm/kubeconfig
 /testrunner run \
     --tm-kubeconfig-path=/tm/kubeconfig \
+    --no-execution-group \
+    --testrun-prefix terraformer-pod-e2e- \
     --timeout=1800 \
     --testruns-chart-path=.ci/testruns/default \
     --set revision="$(cat ./VERSION)"

--- a/.ci/testruns/default/templates/testrun.yaml
+++ b/.ci/testruns/default/templates/testrun.yaml
@@ -7,11 +7,12 @@ spec:
   ttlSecondsAfterFinished: 172800 # 2 days
   {{- if .Values.revision }}
   locationSets:
-    - default: true
-      locations:
-        - type: git
-          repo: https://github.com/gardener/terraformer.git
-          revision: {{ .Values.revision }}
+  - default: true
+    name: terraformer
+    locations:
+    - type: git
+      repo: https://github.com/gardener/terraformer.git
+      revision: {{ .Values.revision }}
   {{- end }}
 
   config:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:

During the release of `v2.0.0`, the `test-e2e` step failed because of some misconfigurations and required flags for the testrunner: see https://concourse.ci.gardener.cloud/teams/gardener/pipelines/terraformer-master/jobs/master-release-job/builds/1
This PR (hopefully) fixes the problem.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @schrodit 

✅ depends on https://github.com/gardener/test-infra/pull/315

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
