### PR TITLE
Fix release test run

### DIFF
--- a/.ci/test-e2e.sh
+++ b/.ci/test-e2e.sh
@@ -8,10 +8,14 @@ cd "$(dirname $0)/.."
 
 mkdir -p /tm
 /cc/utils/cli.py config attribute --cfg-type kubernetes --cfg-name testmachinery --key kubeconfig > /tm/kubeconfig
+# inject the release image tag (content of the VERSION file) as well as the current HEAD commit sha, so that
+# 1) TM can retrieve the needed TestDefinitions (from current HEAD)
+# 2) we will test the actual release docker image instead of a dev image
 /testrunner run \
     --tm-kubeconfig-path=/tm/kubeconfig \
     --no-execution-group \
     --testrun-prefix terraformer-pod-e2e- \
     --timeout=1800 \
     --testruns-chart-path=.ci/testruns/default \
-    --set revision="$(cat ./VERSION)"
+    --set imageTag="$(cat ./VERSION)" \
+    --set revision="$(git rev-parse HEAD)"

--- a/.ci/testruns/default/templates/testrun.yaml
+++ b/.ci/testruns/default/templates/testrun.yaml
@@ -12,6 +12,8 @@ spec:
     locations:
     - type: git
       repo: https://github.com/gardener/terraformer.git
+      # revision will be set to HEAD commit in release jobs (release commit/tag doesn't exist at that point in time)
+      # this way, the test-machinery can get the current TestDefinitions
       revision: {{ .Values.revision }}
   {{- end }}
 
@@ -28,6 +30,16 @@ spec:
         secretKeyRef:
           name: shoot-operator-aws
           key: secretAccessKey
+  {{- if .Values.imageTag }}
+    - name: IMAGE_TAG
+      type: env
+      # Inject the docker image tag which we want to test in the release job (e.g. v2.1.0 instead of
+      # v2.1.0-dev-<commit-sha-of-current-head>).
+      # This test will run after the publish step, that means the tag will already exist and can be used for testing.
+      # In PR tests (via TM bot), we can leave this out, the calculated effective version will be something like
+      # v2.1.0-dev-<commit-sha>, which is the image which we want to test there.
+      value: {{ .Values.imageTag }}
+  {{- end }}
 
   testflow:
     - name: pod-e2e-test

--- a/.test-defs/pod-e2e.yaml
+++ b/.test-defs/pod-e2e.yaml
@@ -14,4 +14,5 @@ spec:
     REGION=$REGION
     ACCESS_KEY_ID_FILE=<(echo $ACCESS_KEY_ID)
     SECRET_ACCESS_KEY_FILE=<(echo $SECRET_ACCESS_KEY)
+    IMAGE_TAG=$IMAGE_TAG
   image: eu.gcr.io/gardener-project/3rd/golang:1.15.3

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,12 @@ IMAGE_REPOSITORY_DEV := $(IMAGE_REPOSITORY)/dev
 REPO_ROOT            := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 VERSION              := $(shell cat "$(REPO_ROOT)/VERSION")
 EFFECTIVE_VERSION    := $(shell $(REPO_ROOT)/hack/get-version.sh)
-IMAGE_TAG            := $(EFFECTIVE_VERSION)
+
+# default IMAGE_TAG if unset (overwritten in release test)
+ifeq ($(IMAGE_TAG),)
+	override IMAGE_TAG = $(EFFECTIVE_VERSION)
+endif
+
 LD_FLAGS             := "-w -X github.com/gardener/$(NAME)/pkg/version.Version=$(IMAGE_TAG)"
 
 REGION                 := eu-west-1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug
/priority normal

**What this PR does / why we need it**:

In the `test-e2e` step during the release job the release tag will not exist on GitHub (yet), so we need to inject the current HEAD commit sha, so that the test-machinery can retrieve the current `TestDefinition`s from the repo.
Though, for the terraformer we still want to inject the docker image tag of the release, which should be tested.

This PR adapts the test run config and so on accordingly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
