### PR TITLE
Remove curl from Terraformer image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# golang-base
-FROM eu.gcr.io/gardener-project/3rd/golang:1.15.5 AS golang-base
+FROM eu.gcr.io/gardener-project/3rd/golang:1.15.7 AS golang-base
 
 ############# terraform-base
 FROM golang-base AS terraform-base
@@ -45,7 +45,8 @@ RUN make install PROVIDER=$PROVIDER
 ############# terraformer
 FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.3 AS terraformer
 
-RUN apk add --update curl tzdata
+# add additional packages that are required by provider plugins
+RUN apk add --update tzdata
 
 WORKDIR /
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind cleanup
/priority normal

**What this PR does / why we need it**:
This PR removes the `curl` package installation from the Dockerfile.

**Special notes for your reviewer**:
/cc @ThormaehlenFred 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Curl has been removed from the Terraformer image.
```
