### PR TITLE
Fix finalizer removal on interrupt

### DIFF
--- a/test/utils/objects.go
+++ b/test/utils/objects.go
@@ -121,6 +121,17 @@ func (o *TestObjects) CleanupTestObjects(ctx context.Context) {
 
 // Refresh retrieves a fresh copy of the objects from the API server, so that tests can make assertions on them.
 func (o *TestObjects) Refresh() {
+	// reset all objects, json encoder doesn't reset removed fields on in-memory objects (e.g. finalizers)
+	o.ConfigurationConfigMap = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: o.ConfigurationConfigMap.Name, Namespace: o.Namespace},
+	}
+	o.StateConfigMap = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: o.StateConfigMap.Name, Namespace: o.Namespace},
+	}
+	o.VariablesSecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: o.VariablesSecret.Name, Namespace: o.Namespace},
+	}
+
 	Expect(o.client.Get(o.ctx, ObjectKeyFromObject(o.ConfigurationConfigMap), o.ConfigurationConfigMap)).To(Succeed())
 	Expect(o.client.Get(o.ctx, ObjectKeyFromObject(o.StateConfigMap), o.StateConfigMap)).To(Succeed())
 	Expect(o.client.Get(o.ctx, ObjectKeyFromObject(o.VariablesSecret), o.VariablesSecret)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness ops-productivity
/kind bug
/priority normal

**What this PR does / why we need it**:

When terraformer is interrupted during terraform destroy execution (i.e. because of a timeout in the infrastructure actuator), it won't remove its finalizer from terraform resources (configmaps and secret), even if the terraform execution was successful and no infrastructure resources are left.
Leaking the finalizers will lead to manual ops effort as it will block the shoot's namespace in the seed to be stuck in termination.

**Special notes for your reviewer**:

Should be cherry-picked to `release-v2.1`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bugfix operator
A bug was fixed that caused terraform to leak its finalizer on ConfigMaps and Secrets in case of an interrupt during `terraform destroy`.
```
