### PR TITLE
Make build logs public

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -6,6 +6,8 @@ terraformer:
       version:
         preprocess: 'inject-commit-hash'
         inject_effective_version: true
+      options:
+        public_build_logs: true
       publish:
         dockerimages:
           terraformer:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Make build logs of this repo public.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/terraformer/pull/73#issuecomment-782825637

**Special notes for your reviewer**:

/invite @AndreasBurger 
Hope it works like this. 
