### PR TITLE
Fix build for tf 0.13

### DIFF
--- a/build/fetch-providers.sh
+++ b/build/fetch-providers.sh
@@ -12,3 +12,5 @@ terraform-bundle \
 
 BUNDLE="$(ls -t terraform*.zip | head -1)"
 unzip -n $BUNDLE
+
+find plugins -name "terraform-provider*" | xargs -I % mv % .


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/priority normal

**What this PR does / why we need it**:

Fix docker build for `terraform@v0.13.x` (currently only used in the `equinixmetal` variant).

`terraform-bundle@v0.13.x` bundles provider plugins in a directory hierarchy like this:
```
./plugins/registry.terraform.io/equinix/metal/1.0.0/linux_amd64/terraform-provider-metal_v1.0.0
```
So we need to move the binaries, so that the docker build can find them under the same path as before.

It seems like buildkit as opposed to plain `docker build` doesn't fail `COPY` if the wildcard doesn't match any files, so that's why `make docker-image` exited with `0` while the pipeline build failed.
Nevertheless, there were no provider plugins in the resulting docker image...

**Which issue(s) this PR fixes**:
Follow-up on https://github.com/gardener/terraformer/pull/73

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
