### PR TITLE
fix COPY problem for slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ ENV TF_RELEASE=true
 
 COPY --from=builder /go/bin/terraformer /
 COPY --from=terraform-base /tmp/terraformer/terraform /bin/terraform
-COPY --from=terraform-base /tmp/terraformer/terraform-provider* /terraform-providers/
+COPY --from=terraform-base /tmp/terraformer/tfproviders/ /terraform-providers/
 
 ENTRYPOINT ["/terraformer"]
 
@@ -66,7 +66,7 @@ WORKDIR /go/src/github.com/gardener/terraformer
 VOLUME /go/src/github.com/gardener/terraformer
 
 COPY --from=terraform-base /tmp/terraformer/terraform /bin/terraform
-COPY --from=terraform-base /tmp/terraformer/terraform-provider* /terraform-providers/
+COPY --from=terraform-base /tmp/terraformer/tfproviders/ /terraform-providers/
 
 COPY vendor vendor
 COPY Makefile VERSION go.mod go.sum ./

--- a/build/fetch-providers.sh
+++ b/build/fetch-providers.sh
@@ -13,4 +13,5 @@ terraform-bundle \
 BUNDLE="$(ls -t terraform*.zip | head -1)"
 unzip -n $BUNDLE
 
-find plugins -name "terraform-provider*" | xargs -I % mv % .
+mkdir "tfproviders"
+find . -name "terraform-provider*" | xargs -I % mv % ./tfproviders/


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/priority normal

**What this PR does / why we need it**:
#77 introduced a new `slim` image variant that comes without any pre-installed terraform plugins. However, since the dockerfile used a wildcard expression to move the plugins to its destination, the build step would fail if no plugins are present. This problem has been avoided by gathering the plugins into a specific folder first and then moving all contents of that folder, which also works if the folder is empty.
During testing, I also noticed that the zip file that is downloaded by the `terraform-bundle` command in the `fetch-providers` script seems to contain the terraform providers not within a `plugins` folder, as it was expected by the script, but on the same level as the `terraform` binary. I therefore adapted the `find` command to also work without the `plugins` folder.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
