### PR TITLE
Prepare verify step for Gardener update

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -56,7 +56,7 @@ terraformer:
               PROVIDER: slim
     steps:
       verify:
-        image: 'eu.gcr.io/gardener-project/3rd/golang:1.15.5'
+        image: 'eu.gcr.io/gardener-project/3rd/golang:1.16.0'
   jobs:
     head-update:
       traits:

--- a/.ci/verify
+++ b/.ci/verify
@@ -9,4 +9,9 @@ cd "$(dirname $0)/.."
 git config --global user.email "gardener@sap.com"
 git config --global user.name "Gardener CI/CD"
 
+# Required because go generate w/ GO111MODULE=off cannot resolve vendor dependencies outside of GOPATH.
+mkdir -p /go/src/github.com/gardener/terraformer
+cp -r . /go/src/github.com/gardener/terraformer
+cd /go/src/github.com/gardener/terraformer
+
 make verify-extended


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind regression
/priority normal

**What this PR does / why we need it**:
With #80 I noticed that the `verify` step constantly fails during `go generate`. It turned out that Go Modules have been disabled for `go generate` in https://github.com/gardener/gardener/pull/3489 and thus vendor-ed dependencies cannot be resolved outside the GOPATH. With this PR we follow the same approach as for other Gardener repos which copy the repo first to the GOPATH before executing further instructions.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
