### PR TITLE
Downgrade to Golang 1.15

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -56,7 +56,7 @@ terraformer:
               PROVIDER: slim
     steps:
       verify:
-        image: 'eu.gcr.io/gardener-project/3rd/golang:1.16.0'
+        image: 'eu.gcr.io/gardener-project/3rd/golang:1.15.8'
   jobs:
     head-update:
       traits:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# golang-base
-FROM eu.gcr.io/gardener-project/3rd/golang:1.16.0 AS golang-base
+FROM eu.gcr.io/gardener-project/3rd/golang:1.15.8 AS golang-base
 
 ############# terraform-base
 FROM golang-base AS terraform-base

--- a/Makefile
+++ b/Makefile
@@ -148,8 +148,8 @@ install-requirements:
 
 .PHONY: revendor
 revendor:
-	@go mod vendor
-	@go mod tidy
+	@GO111MODULE=on go mod vendor
+	@GO111MODULE=on go mod tidy
 	@chmod +x $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/*
 	@chmod +x $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/.ci/*
 	@$(REPO_ROOT)/hack/update-github-templates.sh

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/terraformer
 
-go 1.16
+go 1.15
 
 require (
 	github.com/aws/aws-sdk-go v1.35.26


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind regression
/priority normal

**What this PR does / why we need it**:
Go 1.16 comes with import restrictions which cause the following errors:

```
github.com/gardener/terraformer/hack imports
	github.com/gardener/gardener/.github: malformed import path "github.com/gardener/gardener/.github": leading dot in path element
github.com/gardener/terraformer/hack imports
	github.com/gardener/gardener/.github/ISSUE_TEMPLATE: malformed import path "github.com/gardener/gardener/.github/ISSUE_TEMPLATE": leading dot in path element
github.com/gardener/terraformer/hack imports
	github.com/gardener/gardener/hack/.ci: malformed import path "github.com/gardener/gardener/hack/.ci": leading dot in path element
make[1]: *** [/go/src/github.com/gardener/terraformer/Makefile:151: revendor] Error 1
make[1]: Leaving directory '/go/src/github.com/gardener/terraformer'
make: *** [Makefile:163: check-generate] Error 1
```

We gave feedback in https://github.com/golang/go/issues/43985 and until a decision is made, we downgrade to 1.15 again.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
