### PR TITLE
Update terraform-provider-aws and terraform-provider-google

### DIFF
--- a/build/aws/terraform-bundle.hcl
+++ b/build/aws/terraform-bundle.hcl
@@ -7,7 +7,7 @@ terraform {
 }
 
 providers {
-  aws         = ["3.18.0"]
+  aws         = ["3.32.0"]
   template    = ["2.1.2"]
   null        = ["2.1.2"]
 }

--- a/build/gcp/terraform-bundle.hcl
+++ b/build/gcp/terraform-bundle.hcl
@@ -7,8 +7,8 @@ terraform {
 }
 
 providers {
-  google      = ["3.27.0"]
-  google-beta = ["3.27.0"]
+  google      = ["3.59.0"]
+  google-beta = ["3.59.0"]
   template    = ["2.1.2"]
   null        = ["2.1.2"]
 }


### PR DESCRIPTION
/area quality
/kind enhancement

With the new versions of terraform-provider-aws and terraform-provider-google I locally successfully validated the following scenarios for both of the providers:
- reconciliation of existing `Infrastructure`
- deletion of existing `Infrastructure`
- creation and deletion of new `Infrastructure` (single zone, new vpc)
- creation and deletion of new `Infrastructure` (multiple zones, new vpc) (not applicable for gcp as gcp `Infrastructure` is not zoned)
- creation and deletion of new `Infrastructure` (single zone, existing vpc)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following terraform provider plugins are updated:
- hashicorp/terraform-provider-aws: 3.18.0 -> 3.32.0
- hashicorp/terraform-provider-google: 3.27.0 -> 3.59.0
- hashicorp/terraform-provider-google-beta: 3.27.0 -> 3.59.0
```
