### PR TITLE
Update hashicorp/terraform-provider-aws

### DIFF
--- a/build/aws/terraform-bundle.hcl
+++ b/build/aws/terraform-bundle.hcl
@@ -7,7 +7,7 @@ terraform {
 }
 
 providers {
-  aws         = ["3.32.0"]
+  aws         = ["3.34.0"]
   template    = ["2.1.2"]
   null        = ["2.1.2"]
 }


### PR DESCRIPTION
/kind enhancement

We have the following issues reported in the upstream terraform-provider-aws - https://github.com/hashicorp/terraform-provider-aws/issues/12073 and https://github.com/hashicorp/terraform-provider-aws/issues/12829. They were open for a quite long period of time. It seems that they are now both fixed (hopefully) in 3.34.0.

With the new versions of terraform-provider-aws I locally successfully validated the following scenarios:
- reconciliation of existing `Infrastructure`
- deletion of existing `Infrastructure`
- creation and deletion of new `Infrastructure` (single zone, new vpc)
- creation and deletion of new `Infrastructure` (multiple zones, new vpc)
- creation and deletion of new `Infrastructure` (single zone, existing vpc)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following terraform provider plugin is updated:
- hashicorp/terraform-provider-aws: 3.32.0 -> 3.34.0
```
