### PR TITLE
Revert "Update hashicorp/terraform-provider-aws"

### DIFF
--- a/build/aws/terraform-bundle.hcl
+++ b/build/aws/terraform-bundle.hcl
@@ -7,7 +7,7 @@ terraform {
 }
 
 providers {
-  aws         = ["3.32.0"]
+  aws         = ["3.18.0"]
   template    = ["2.1.2"]
   null        = ["2.1.2"]
 }


### PR DESCRIPTION
This reverts commit 320ca1eb9ef783a1ba2a32c1c03f7bf93762c53b.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind regression
/priority normal

**What this PR does / why we need it**:
Downgrade AWS provider to `3.18.0`.
The newer version require additional permissions, e.g. iam:ListRolePolicies.
but we need time to announce such change in advance and request users to
update their policies accordingly.


**Which issue(s) this PR fixes**:
Partially reverts #84 
More info https://github.com/gardener/gardener-extension-provider-aws/pull/301

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The aws provider has been downgraded to `3.18.0` due to issue with additionally required permission for the AWS accounts.
```
