### PR TITLE
Update hashicorp/terraform-provider-google

### DIFF
--- a/build/gcp/terraform-bundle.hcl
+++ b/build/gcp/terraform-bundle.hcl
@@ -7,8 +7,8 @@ terraform {
 }
 
 providers {
-  google      = ["3.59.0"]
-  google-beta = ["3.59.0"]
+  google      = ["3.62.0"]
+  google-beta = ["3.62.0"]
   template    = ["2.1.2"]
   null        = ["2.1.2"]
 }


### PR DESCRIPTION
/kind enhancement

We have the following issue reported in the upstream terraform-provider-google - https://github.com/hashicorp/terraform-provider-google/issues/8655. The fix for this issue was included in the most recent release - `terraform-provider-google@3.62.0`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following terraform provider plugins are updated:
- hashicorp/terraform-provider-google: 3.59.0 -> 3.62.0
- hashicorp/terraform-provider-google-beta: 3.59.0 -> 3.62.0
```
