### PR TITLE
Revert to the default concourse image builder

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,7 +9,6 @@ terraformer:
       options:
         public_build_logs: true
       publish:
-        oci-builder: 'kaniko'
         dockerimages:
           terraformer:
             registry: 'gcr-readwrite'
@@ -59,7 +58,7 @@ terraformer:
               PROVIDER: slim
     steps:
       verify:
-        image: 'golang:1.16.2'
+        image: 'eu.gcr.io/gardener-project/3rd/golang:1.16.2'
   jobs:
     head-update:
       traits:
@@ -74,7 +73,7 @@ terraformer:
           execute:
           - test-e2e.sh
           depends:
-          - build_oci_image_terraformer
+          - publish
           image: 'eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable'
       traits:
         version:
@@ -89,7 +88,6 @@ terraformer:
               slack_cfg_name: 'scp_workspace'
         component_descriptor: ~
         publish:
-          oci-builder: 'kaniko'
           dockerimages:
             terraformer:
               tag_as_latest: true

--- a/.test-defs/pod-e2e.yaml
+++ b/.test-defs/pod-e2e.yaml
@@ -15,4 +15,4 @@ spec:
     ACCESS_KEY_ID_FILE=<(echo $ACCESS_KEY_ID)
     SECRET_ACCESS_KEY_FILE=<(echo $SECRET_ACCESS_KEY)
     IMAGE_TAG=$IMAGE_TAG
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# golang-base
-FROM golang:1.16.2 AS golang-base
+FROM eu.gcr.io/gardener-project/3rd/golang:1.16.2 AS golang-base
 
 ############# terraform-base
 FROM golang-base AS terraform-base
@@ -43,7 +43,7 @@ ARG PROVIDER=all
 RUN make install PROVIDER=$PROVIDER
 
 ############# terraformer
-FROM alpine:3.13.2 AS terraformer
+FROM eu.gcr.io/gardener-project/3rd/alpine:3.13.2 AS terraformer
 
 # add additional packages that are required by provider plugins
 RUN apk add --update tzdata


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind regression

**What this PR does / why we need it**:
Partially revert 6fc87de91c9c3567ce06082f21d5ea1d9ec26f77 due to issues
with the build args when kaniko is used

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
