### PR TITLE
Maintain the provider version updates for the "all" image variant

### DIFF
--- a/build/all/terraform-bundle.hcl
+++ b/build/all/terraform-bundle.hcl
@@ -9,9 +9,9 @@ terraform {
 providers {
   aws         = ["3.18.0"]
   azurerm     = ["2.36.0"]
-  google      = ["3.27.0"]
-  google-beta = ["3.27.0"]
-  openstack   = ["1.28.0"]
+  google      = ["3.62.0"]
+  google-beta = ["3.62.0"]
+  openstack   = ["1.37.0"]
   alicloud    = ["1.103.0"]
   packet      = ["2.3.0"]
   template    = ["2.1.2"]


### PR DESCRIPTION
/kind cleanup

It is something that we definitely missed in the last terraform-provider-* version updates PR such as https://github.com/gardener/terraformer/pull/88 and https://github.com/gardener/terraformer/pull/70.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
