### PR TITLE
Make terraform error output available in termination log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 *~
 
 .cache_ggshield
+.gitguardian.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,9 +53,9 @@ WORKDIR /
 ENV TF_DEV=true
 ENV TF_RELEASE=true
 
-COPY --from=builder /go/bin/terraformer /
 COPY --from=terraform-base /tmp/terraformer/terraform /bin/terraform
 COPY --from=terraform-base /tmp/terraformer/tfproviders/ /terraform-providers/
+COPY --from=builder /go/bin/terraformer /
 
 ENTRYPOINT ["/terraformer"]
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ infrastructure operations on Pod deletion.
 If the Terraform command execution fails (e.g. because of invalid credentials or similar), Terraformer will copy
 Terraform's logs to `$base_dir/terraform-termination-log` (where `$base_dir` is the directory specified in the
 `--base-dir` command line flag (defaults to `/`)). Controllers deploying Terraformer Pods for infrastructure management
-can set `Container.terminationMessagePath` to this file path to have the `kubelet` populate the
-`Pod.status.containerStatuses[].lastState.terminated.message` field (see this [doc](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/#customizing-the-termination-message)
+can set `spec.containers[].terminationMessagePath` in the `Pod` specification to this file path to have the `kubelet`
+populate the `.status.containerStatuses[].lastState.terminated.message` field (see this [doc](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/#customizing-the-termination-message)
 for reference). It can then be used to detect error codes from the Terraform logs without fetching all Pods logs,
 that also include info messages from Terraformer.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,38 @@ Apart from dealing with Terraform configuration and state, Terraformer also hand
 signals. It will try to relay `SIGINT` and `SIGTERM` to the running Terraform process in order to stop the ongoing
 infrastructure operations on Pod deletion.
 
+## Termination log
+
+If the Terraform command execution fails (e.g. because of invalid credentials or similar), Terraformer will copy
+Terraform's logs to `$base_dir/terraform-termination-log` (where `$base_dir` is the directory specified in the
+`--base-dir` command line flag (defaults to `/`)). Controllers deploying Terraformer Pods for infrastructure management
+can set `Container.terminationMessagePath` to this file path to have the `kubelet` populate the
+`Pod.status.containerStatuses[].lastState.terminated.message` field (see this [doc](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/#customizing-the-termination-message)
+for reference). It can then be used to detect error codes from the Terraform logs without fetching all Pods logs,
+that also include info messages from Terraformer.
+
+The Pod status will then look similar to this:
+
+```yaml
+status:
+  containerStatuses:
+  - name: terraformer
+    ready: false
+    restartCount: 0
+    started: false
+    state:
+      terminated:
+        exitCode: 1
+        finishedAt: "2021-04-26T10:28:40Z"
+        message: "\nError: error configuring Terraform AWS Provider: error validating
+          provider credentials: error calling sts:GetCallerIdentity: SignatureDoesNotMatch:
+          The request signature we calculated does not match the signature you provided.
+          Check your AWS Secret Access Key and signing method. Consult the service
+          documentation for details.\n\tstatus code: 403, request id: 49163947-9edf-4c44-ae7d-b013b119442a\n\n\n"
+        reason: Error
+        startedAt: "2021-04-26T10:28:32Z"
+```
+
 ## How to run it locally
 
 The `Makefile` specifies targets for running and developing Terraformer locally:

--- a/example/20-terraformer-validate-pod.yaml
+++ b/example/20-terraformer-validate-pod.yaml
@@ -12,7 +12,7 @@ spec:
   activeDeadlineSeconds: 1800
   containers:
   - name: terraform
-    image: eu.gcr.io/gardener-project/gardener/terraformer:v2.0.0
+    image: eu.gcr.io/gardener-project/gardener/terraformer:v2.6.0
     imagePullPolicy: IfNotPresent
     command:
     - /terraformer
@@ -24,6 +24,7 @@ spec:
     resources:
       requests:
         cpu: 100m
+    terminationMessagePath: /terraform-termination-log
   restartPolicy: Never
   serviceAccountName: terraformer
   terminationGracePeriodSeconds: 600

--- a/example/30-terraformer-apply-pod.yaml
+++ b/example/30-terraformer-apply-pod.yaml
@@ -12,7 +12,7 @@ spec:
   activeDeadlineSeconds: 1800
   containers:
   - name: terraform
-    image: eu.gcr.io/gardener-project/gardener/terraformer:v2.0.0
+    image: eu.gcr.io/gardener-project/gardener/terraformer:v2.6.0
     imagePullPolicy: IfNotPresent
     command:
     - /terraformer
@@ -24,6 +24,7 @@ spec:
     resources:
       requests:
         cpu: 100m
+    terminationMessagePath: /terraform-termination-log
   restartPolicy: Never
   serviceAccountName: terraformer
   terminationGracePeriodSeconds: 600

--- a/example/40-terraformer-destroy-pod.yaml
+++ b/example/40-terraformer-destroy-pod.yaml
@@ -12,7 +12,7 @@ spec:
   activeDeadlineSeconds: 1800
   containers:
   - name: terraform
-    image: eu.gcr.io/gardener-project/gardener/terraformer:v2.0.0
+    image: eu.gcr.io/gardener-project/gardener/terraformer:v2.6.0
     imagePullPolicy: IfNotPresent
     command:
     - /terraformer
@@ -24,6 +24,7 @@ spec:
     resources:
       requests:
         cpu: 100m
+    terminationMessagePath: /terraform-termination-log
   restartPolicy: Never
   serviceAccountName: terraformer
   terminationGracePeriodSeconds: 600

--- a/pkg/terraformer/paths.go
+++ b/pkg/terraformer/paths.go
@@ -24,7 +24,7 @@ type PathSet struct {
 	ProvidersDir string
 
 	// TerminationMessagePath is the file, which the termination log should be written to.
-	// Should be used as Container.terminationMessagePath in the terraformer pod spec,
+	// Should be used as spec.containers[].terminationMessagePath in the terraformer pod spec,
 	// see https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/
 	TerminationMessagePath string
 

--- a/pkg/terraformer/paths.go
+++ b/pkg/terraformer/paths.go
@@ -23,6 +23,11 @@ type PathSet struct {
 	// ProvidersDir is the directory which contains the provider plugin binaries
 	ProvidersDir string
 
+	// TerminationMessagePath is the file, which the termination log should be written to.
+	// Should be used as Container.terminationMessagePath in the terraformer pod spec,
+	// see https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/
+	TerminationMessagePath string
+
 	// VarsPath is the complete path the the variables values file
 	VarsPath string
 	// StatePath is the complete path the the state file
@@ -32,10 +37,11 @@ type PathSet struct {
 // DefaultPaths returns the default PathSet used in terraformer
 func DefaultPaths() *PathSet {
 	p := &PathSet{
-		ConfigDir:    "/tf",
-		VarsDir:      "/tfvars",
-		StateDir:     "/tfstate",
-		ProvidersDir: "/terraform-providers",
+		ConfigDir:              "/tf",
+		VarsDir:                "/tfvars",
+		StateDir:               "/tfstate",
+		ProvidersDir:           "/terraform-providers",
+		TerminationMessagePath: "/terraform-termination-log",
 	}
 	p.VarsPath = path.Join(p.VarsDir, tfVarsKey)
 	p.StatePath = path.Join(p.StateDir, tfStateKey)
@@ -47,12 +53,13 @@ func DefaultPaths() *PathSet {
 // This is used for testing purposes to use paths located e.g. under temporary directories.
 func (p *PathSet) WithBaseDir(baseDir string) *PathSet {
 	return &PathSet{
-		ConfigDir:    filepath.Join(baseDir, p.ConfigDir),
-		VarsDir:      filepath.Join(baseDir, p.VarsDir),
-		StateDir:     filepath.Join(baseDir, p.StateDir),
-		ProvidersDir: filepath.Join(baseDir, p.ProvidersDir),
-		VarsPath:     filepath.Join(baseDir, p.VarsPath),
-		StatePath:    filepath.Join(baseDir, p.StatePath),
+		ConfigDir:              filepath.Join(baseDir, p.ConfigDir),
+		VarsDir:                filepath.Join(baseDir, p.VarsDir),
+		StateDir:               filepath.Join(baseDir, p.StateDir),
+		ProvidersDir:           filepath.Join(baseDir, p.ProvidersDir),
+		TerminationMessagePath: filepath.Join(baseDir, p.TerminationMessagePath),
+		VarsPath:               filepath.Join(baseDir, p.VarsPath),
+		StatePath:              filepath.Join(baseDir, p.StatePath),
 	}
 }
 

--- a/pkg/terraformer/terraformer.go
+++ b/pkg/terraformer/terraformer.go
@@ -196,7 +196,8 @@ func (t *Terraformer) executeTerraform(ctx context.Context, command Command) err
 	}
 	defer terminationLogFile.Close()
 
-	args := []string{string(command)}
+	// disable colors, which will look weird in termination message, k8s status fields and so on
+	args := []string{string(command), "-no-color"}
 
 	switch command {
 	case Init:

--- a/test/e2e/binary/binary_test.go
+++ b/test/e2e/binary/binary_test.go
@@ -409,12 +409,15 @@ var _ = Describe("terraformer", func() {
 			Context("terraform commands succeed", func() {
 				It("should return exit code 0 if apply succeeds", func() {
 					runExitCodeTest("apply", 0)
+					Expect(paths.TerminationMessagePath).To(testutils.BeEmptyFile())
 				})
 				It("should return exit code 0 if destroy succeeds", func() {
 					runExitCodeTest("destroy", 0)
+					Expect(paths.TerminationMessagePath).To(testutils.BeEmptyFile())
 				})
 				It("should return exit code 0 if validate and plan succeed", func() {
 					runExitCodeTest("validate", 0)
+					Expect(paths.TerminationMessagePath).To(testutils.BeEmptyFile())
 				})
 			})
 
@@ -426,6 +429,10 @@ var _ = Describe("terraformer", func() {
 				})
 				It("should return exit code from terraform init", func() {
 					runExitCodeTest("apply", 12)
+					Expect(paths.TerminationMessagePath).To(testutils.BeFileWithContents(And(
+						ContainSubstring("args: init"),
+						ContainSubstring("some terraform error"),
+					)), "termination log should contain all terraform logs")
 				})
 			})
 
@@ -441,12 +448,27 @@ var _ = Describe("terraformer", func() {
 
 				It("should return exit code from terraform apply", func() {
 					runExitCodeTest("apply", 42)
+					Expect(paths.TerminationMessagePath).To(testutils.BeFileWithContents(And(
+						ContainSubstring("args: apply"),
+						ContainSubstring("doing some long running IaaS ops"),
+						ContainSubstring("some terraform error"),
+					)), "termination log should contain all terraform logs")
 				})
 				It("should return exit code from terraform destroy", func() {
 					runExitCodeTest("destroy", 43)
+					Expect(paths.TerminationMessagePath).To(testutils.BeFileWithContents(And(
+						ContainSubstring("args: destroy"),
+						ContainSubstring("doing some long running IaaS ops"),
+						ContainSubstring("some terraform error"),
+					)), "termination log should contain all terraform logs")
 				})
 				It("should return exit code from terraform validate", func() {
 					runExitCodeTest("validate", 44)
+					Expect(paths.TerminationMessagePath).To(testutils.BeFileWithContents(And(
+						ContainSubstring("args: validate"),
+						ContainSubstring("doing some long running IaaS ops"),
+						ContainSubstring("some terraform error"),
+					)), "termination log should contain all terraform logs")
 				})
 
 				Context("validate succeeds, but plan fails", func() {
@@ -459,6 +481,12 @@ var _ = Describe("terraformer", func() {
 					})
 					It("should return exit code from terraform plan", func() {
 						runExitCodeTest("validate", 45)
+						Expect(paths.TerminationMessagePath).To(testutils.BeFileWithContents(And(
+							Not(ContainSubstring("args: validate")),
+							ContainSubstring("args: plan"),
+							ContainSubstring("doing some long running IaaS ops"),
+							ContainSubstring("some terraform error"),
+						)), "termination log should contain all terraform logs")
 					})
 				})
 			})

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+)
+
+// BeFileWithContents succeeds if actual is an absolute path to a file, that exists and its contents matches the given
+// content matcher.
+func BeFileWithContents(contentMatcher types.GomegaMatcher) types.GomegaMatcher {
+	return &fileContentsMatcher{contentMatcher}
+}
+
+// BeEmptyFile succeeds if actual is an absolute path to a file, that exists and is empty.
+func BeEmptyFile() types.GomegaMatcher {
+	return BeFileWithContents(BeEmpty())
+}
+
+type fileContentsMatcher struct {
+	expectedContents types.GomegaMatcher
+}
+
+func (matcher *fileContentsMatcher) Match(actual interface{}) (success bool, err error) {
+	actualFilename, ok := actual.(string)
+	if !ok {
+		return false, fmt.Errorf("beFileWithContents matcher expects a file path")
+	}
+
+	file, err := os.Open(actualFilename)
+	if err != nil {
+		return false, err
+	}
+
+	fileContents, err := io.ReadAll(file)
+	if err != nil {
+		return false, err
+	}
+
+	return matcher.expectedContents.Match(string(fileContents))
+}
+
+func (matcher *fileContentsMatcher) FailureMessage(actual interface{}) string {
+	return matcher.expectedContents.FailureMessage(actual)
+}
+
+func (matcher *fileContentsMatcher) NegatedFailureMessage(actual interface{}) string {
+	return matcher.expectedContents.NegatedFailureMessage(actual)
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:

Make terraform error output available in termination log as described in #67.

Also
- disable terraform colorized output 
- copy terraformer binary after tf and plugins (for faster subsequent pushes during development)

**Which issue(s) this PR fixes**:
Fixes #67

**Special notes for your reviewer**:

/keep-commits

In draft until I've made adaptions in `g/g/ext/terraformer` and tested this end-to-end with `g/aws`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Terraformer now copies Terraform's error outputs to `/terraform-termination-log` to make it available in the containers termination message for better analyzing and more readable error messages (e.g. in the Shoot status).
```
