### PR TITLE
[release-v2.7] Automated cherry pick of #96: upgrade TF provider 1.124.2

### DIFF
--- a/build/alicloud/terraform-bundle.hcl
+++ b/build/alicloud/terraform-bundle.hcl
@@ -7,7 +7,7 @@ terraform {
 }
 
 providers {
-  alicloud    = ["1.124.0"]
+  alicloud    = ["1.124.2"]
   template    = ["2.1.2"]
   null        = ["2.1.2"]
 }

--- a/build/all/terraform-bundle.hcl
+++ b/build/all/terraform-bundle.hcl
@@ -12,7 +12,7 @@ providers {
   google      = ["3.62.0"]
   google-beta = ["3.62.0"]
   openstack   = ["1.37.0"]
-  alicloud    = ["1.124.0"]
+  alicloud    = ["1.124.2"]
   packet      = ["2.3.0"]
   template    = ["2.1.2"]
   null        = ["2.1.2"]


### PR DESCRIPTION
/area/open-source
/kind/bug

Cherry pick of #96 on release-v2.7.

#96: upgrade TF provider 1.124.2

**Release Notes:**
```other operator
The following terraform provider plugin is updated:
- aliyun/terraform-provider-alicloud: 1.124.0 -> 1.124.2
```