### PR TITLE
Update hashicorp/terraform-provider-aws

### DIFF
--- a/build/all/terraform-bundle.hcl
+++ b/build/all/terraform-bundle.hcl
@@ -7,7 +7,7 @@ terraform {
 }
 
 providers {
-  aws         = ["3.18.0"]
+  aws         = ["3.32.0"]
   azurerm     = ["2.36.0"]
   google      = ["3.62.0"]
   google-beta = ["3.62.0"]

--- a/build/aws/terraform-bundle.hcl
+++ b/build/aws/terraform-bundle.hcl
@@ -7,7 +7,7 @@ terraform {
 }
 
 providers {
-  aws         = ["3.18.0"]
+  aws         = ["3.32.0"]
   template    = ["2.1.2"]
   null        = ["2.1.2"]
 }


### PR DESCRIPTION
/area quality
/kind enhancement

Reopen of https://github.com/gardener/terraformer/pull/84/commits/320ca1eb9ef783a1ba2a32c1c03f7bf93762c53b

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following terraform provider plugins are updated:
- hashicorp/terraform-provider-aws: 3.18.0 -> 3.32.0
```
