### PR TITLE
Fix `fetch-providers.sh` script for Terraform >= 0.13

### DIFF
--- a/build/fetch-providers.sh
+++ b/build/fetch-providers.sh
@@ -4,14 +4,26 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+TF_VERSION="$(cat ./TF_VERSION)"
+function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; } # https://apple.stackexchange.com/a/123408/11374
+
 terraform-bundle \
   package \
   -os=linux \
   -arch=amd64 \
-  <(cat ./terraform-bundle.hcl | sed "s/TF_VERSION/$(cat ./TF_VERSION)/g")
+  <(cat ./terraform-bundle.hcl | sed "s/TF_VERSION/$TF_VERSION/g")
 
 BUNDLE="$(ls -t terraform*.zip | head -1)"
 unzip -n $BUNDLE
 
-mkdir "tfproviders"
-find . -name "terraform-provider*" | xargs -I % mv % ./tfproviders/
+if [ "$(version "$TF_VERSION")" -lt "$(version "0.13.0")" ]; then
+  mkdir "tfproviders"
+  find . -name "terraform-provider*" | xargs -I % cp % ./tfproviders/
+else
+  # Beginning with Terraform 0.13, plugins must be installed in a file system with the following hierarchy:
+  # registry.terraform.io/<username>/<plugin-name>/<version>/<arch>
+  # Above `terraform-bundle` command already maintains such structure, hence, we keep it instead of copying
+  # the `terraform-provider` binaries.
+  find . -name "*.md" | xargs -I % rm -f %
+  mv ./plugins ./tfproviders/
+fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability open-source
/kind bug
/priority 3

**What this PR does / why we need it**:
Beginning with Terraform 0.13, plugins must be installed in a file system with the following hierarchy:
`registry.terraform.io/<username>/<plugin-name>/<version>/<arch>`

❗ Please note that this will PR is not enough to enable updating a Terraform version from < 0.13 to >= 0.13. It only works well for new providers (like `equinixmetal`).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
A bug has been fixed preventing to use Terraformer with a Terraform version >= 0.13.
```
