### PR TITLE
Update EQXM provider version to 3.1.0

### DIFF
--- a/build/equinixmetal/terraform-bundle.hcl
+++ b/build/equinixmetal/terraform-bundle.hcl
@@ -8,13 +8,7 @@ terraform {
 
 providers {
   metal     = {
-    versions = ["1.0.0"]
+    versions = ["3.1.0"]
     source = "equinix/metal"
-  }
-  template  = {
-    versions = ["2.1.2"]
-  }
-  null      = {
-    versions = ["2.1.2"]
   }
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Update EQXM provider version to 3.1.0

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
The version for the `equinixmetal` Terraform provider plugin has been updated to `3.1.0`.
```
