### PR TITLE
Update hashicorp/terraform-provider-aws

### DIFF
--- a/build/all/terraform-bundle.hcl
+++ b/build/all/terraform-bundle.hcl
@@ -7,7 +7,7 @@ terraform {
 }
 
 providers {
-  aws         = ["3.54.0"]
+  aws         = ["3.63.0"]
   azurerm     = ["2.68.0"]
   google      = ["3.62.0"]
   google-beta = ["3.62.0"]

--- a/build/aws/terraform-bundle.hcl
+++ b/build/aws/terraform-bundle.hcl
@@ -7,7 +7,7 @@ terraform {
 }
 
 providers {
-  aws         = ["3.54.0"]
+  aws         = ["3.63.0"]
   template    = ["2.1.2"]
   null        = ["2.1.2"]
 }


### PR DESCRIPTION
/area quality
/kind enhancement

With the new version of terraform-provider-aws I locally successfully validated the following scenarios for the provider:
- reconciliation of existing `Infrastructure`
- deletion of existing `Infrastructure`
- creation and deletion of new `Infrastructure` (single zone, new vpc)
- creation and deletion of new `Infrastructure` (multiple zones, new vpc)
- creation and deletion of new `Infrastructure` (single zone, existing vpc)
- creation and deletion of new `Infrastructure` (multiple zone, existing vpc)
- gardener-extension-provider-aws Infrastructure integration test

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following terraform provider plugins are updated:
- hashicorp/terraform-provider-aws: 3.54.0 -> 3.63.0
```
