### PR TITLE
[release-v2.13] Automated cherry pick of #108: Update hashicorp/terraform-provider-aws

### DIFF
--- a/build/all/terraform-bundle.hcl
+++ b/build/all/terraform-bundle.hcl
@@ -8,7 +8,7 @@ terraform {
 
 providers {
   aws = {
-    versions = ["3.63.0"]
+    versions = ["3.66.0"]
   }
   azurerm = {
     versions = ["2.68.0"]

--- a/build/aws/terraform-bundle.hcl
+++ b/build/aws/terraform-bundle.hcl
@@ -8,7 +8,7 @@ terraform {
 
 providers {
   aws = {
-    versions = ["3.63.0"]
+    versions = ["3.66.0"]
   }
   template = {
     versions = ["2.1.2"]


### PR DESCRIPTION
/kind/enhancement
/area/quality

Cherry pick of #108 on release-v2.13.

#108: Update hashicorp/terraform-provider-aws

**Release Notes:**
```other operator
The following terraform provider plugins are updated:
- hashicorp/terraform-provider-aws: 3.63.0 -> 3.66.0
```