### PR TITLE
[release-v2.12] Cherry pick of #108: Update hashicorp/terraform-provider-aws

### DIFF
--- a/build/all/terraform-bundle.hcl
+++ b/build/all/terraform-bundle.hcl
@@ -7,7 +7,7 @@ terraform {
 }
 
 providers {
-  aws         = ["3.63.0"]
+  aws         = ["3.66.0"]
   azurerm     = ["2.68.0"]
   google      = ["3.62.0"]
   google-beta = ["3.62.0"]

--- a/build/aws/terraform-bundle.hcl
+++ b/build/aws/terraform-bundle.hcl
@@ -7,7 +7,7 @@ terraform {
 }
 
 providers {
-  aws         = ["3.63.0"]
+  aws         = ["3.66.0"]
   template    = ["2.1.2"]
   null        = ["2.1.2"]
 }


### PR DESCRIPTION
/kind/enhancement
/area/quality

Cherry pick of #108 on release-v2.13.

#108: Update hashicorp/terraform-provider-aws

**Release Notes:**
```other operator
The following terraform provider plugins are updated:
- hashicorp/terraform-provider-aws: 3.63.0 -> 3.66.0
```