### PR TITLE
Add build badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Terraformer
 
+[![CI Build status](https://concourse.ci.gardener.cloud/api/v1/teams/gardener/pipelines/terraformer-master/jobs/master-head-update-job/badge)](https://concourse.ci.gardener.cloud/teams/gardener/pipelines/terraformer-master/jobs/master-head-update-job)
+
 Terraformer is a tool that can execute Terraform commands (`apply`, `destroy` and `validate`) and can be run as a Pod
 inside a Kubernetes cluster.
 The Terraform configuration and state files (`main.tf`, `variables.tf`, `terraform.tfvars` and `terraform.tfstate`)


### PR DESCRIPTION
**What this PR does / why we need it**:
To make the README.md consistent with the README.mds in the gardener and the build badge is convenient way to navigate directly to concourse. It can also signal for a failing/failed build.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
