### PR TITLE
[release-v2.18] Automated cherry pick of #124: Update the golang and alpine base images

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -59,7 +59,7 @@ terraformer:
               PROVIDER: slim
     steps:
       verify:
-        image: 'golang:1.16.3'
+        image: 'golang:1.16.15'
   jobs:
     head-update:
       traits:

--- a/.test-defs/pod-e2e.yaml
+++ b/.test-defs/pod-e2e.yaml
@@ -15,4 +15,4 @@ spec:
     ACCESS_KEY_ID_FILE=<(echo $ACCESS_KEY_ID)
     SECRET_ACCESS_KEY_FILE=<(echo $SECRET_ACCESS_KEY)
     IMAGE_TAG=$IMAGE_TAG
-  image: golang:1.16.3
+  image: golang:1.16.15

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# golang-base
-FROM golang:1.16.3 AS golang-base
+FROM golang:1.16.15 AS golang-base
 
 ############# terraform-base
 FROM golang-base AS terraform-base
@@ -43,7 +43,7 @@ ARG PROVIDER=all
 RUN make install PROVIDER=$PROVIDER
 
 ############# terraformer
-FROM alpine:3.15.4 AS terraformer
+FROM alpine:3.16.2 AS terraformer
 
 # add additional packages that are required by provider plugins
 RUN apk add --update tzdata


### PR DESCRIPTION
/kind/enhancement
/area/control-plane

Cherry pick of #124 on release-v2.18.

#124: Update the golang and alpine base images

**Release Notes:**
```other operator
The golang base image is now updated to 1.16.15. The alpine base image is updated to 3.16.2.
```