### PR TITLE
Update `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # terraformer maintainers
-*   @gardener/gardener-maintainers
+*   @gardener/gardener-extensions-maintainers
 
-/build/all/**          @gardener/gardener-maintainers @gardener/gardener-extension-provider-alicloud-maintainers @gardener/gardener-extension-provider-aws-maintainers @gardener/gardener-extension-provider-azure-maintainers @gardener/gardener-extension-provider-gcp-maintainers @gardener/gardener-extension-provider-openstack-maintainers @gardener/gardener-extension-provider-equinix-metal-maintainers
+/build/all/**          @gardener/gardener-extension-provider-alicloud-maintainers @gardener/gardener-extension-provider-aws-maintainers @gardener/gardener-extension-provider-azure-maintainers @gardener/gardener-extension-provider-gcp-maintainers @gardener/gardener-extension-provider-openstack-maintainers @gardener/gardener-extension-provider-equinix-metal-maintainers
 /build/alicloud/**     @gardener/gardener-extension-provider-alicloud-maintainers
 /build/aws/**          @gardener/gardener-extension-provider-aws-maintainers
 /build/azure/**        @gardener/gardener-extension-provider-azure-maintainers


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:

Drop the historical @gardener/gardener-maintainers ownership in favor of the new @gardener/gardener-extensions-maintainers team.
This makes it easier for folks actually working on the extensions and this repo to merge their own PRs (e.g. https://github.com/gardener/terraformer/pull/126)  😄 
