### PR TITLE
Bump alpine base image to 3.17.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ARG PROVIDER=all
 RUN make install PROVIDER=$PROVIDER
 
 ############# terraformer
-FROM alpine:3.16.2 AS terraformer
+FROM alpine:3.17.2 AS terraformer
 
 # add additional packages that are required by provider plugins
 RUN apk add --update tzdata


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Bump alpine base image to 3.17.2

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Terrafomer base image has been updated to alpine:3.17.2
```
