### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -4,13 +4,15 @@ terraformer:
       version:
         preprocess: 'inject-commit-hash'
         inject_effective_version: true
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       options:
         public_build_logs: true
       publish:
         oci-builder: 'docker-buildx'
         dockerimages:
           terraformer:
-            image: 'eu.gcr.io/gardener-project/gardener/terraformer'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/terraformer
             target: terraformer
             resource_labels:
             - name: 'gardener.cloud/cve-categorisation'
@@ -22,7 +24,7 @@ terraformer:
                 integrity_requirement: 'high'
                 availability_requirement: 'low'
           terraformer-alicloud:
-            image: 'eu.gcr.io/gardener-project/gardener/terraformer-alicloud'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/terraformer-alicloud
             target: terraformer
             build_args:
               PROVIDER: alicloud
@@ -36,7 +38,7 @@ terraformer:
                 integrity_requirement: 'high'
                 availability_requirement: 'low'
           terraformer-aws:
-            image: 'eu.gcr.io/gardener-project/gardener/terraformer-aws'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/terraformer-aws
             target: terraformer
             build_args:
               PROVIDER: aws
@@ -50,7 +52,7 @@ terraformer:
                 integrity_requirement: 'high'
                 availability_requirement: 'low'
           terraformer-azure:
-            image: 'eu.gcr.io/gardener-project/gardener/terraformer-azure'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/terraformer-azure
             target: terraformer
             build_args:
               PROVIDER: azure
@@ -64,7 +66,7 @@ terraformer:
                 integrity_requirement: 'high'
                 availability_requirement: 'low'
           terraformer-gcp:
-            image: 'eu.gcr.io/gardener-project/gardener/terraformer-gcp'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/terraformer-gcp
             target: terraformer
             build_args:
               PROVIDER: gcp
@@ -78,7 +80,7 @@ terraformer:
                 integrity_requirement: 'high'
                 availability_requirement: 'low'
           terraformer-openstack:
-            image: 'eu.gcr.io/gardener-project/gardener/terraformer-openstack'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/terraformer-openstack
             target: terraformer
             build_args:
               PROVIDER: openstack
@@ -92,7 +94,7 @@ terraformer:
                 integrity_requirement: 'high'
                 availability_requirement: 'low'
           terraformer-equinixmetal:
-            image: 'eu.gcr.io/gardener-project/gardener/terraformer-equinixmetal'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/terraformer-equinixmetal
             target: terraformer
             build_args:
               PROVIDER: equinixmetal
@@ -106,7 +108,7 @@ terraformer:
                 policy: 'skip'
                 comment: only open source related component
           terraformer-slim:
-            image: 'eu.gcr.io/gardener-project/gardener/terraformer-slim'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/terraformer-slim
             target: terraformer
             build_args:
               PROVIDER: slim
@@ -123,7 +125,9 @@ terraformer:
     head-update:
       traits:
         draft_release: ~
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
     pull-request:
       traits:
         pull-request: ~
@@ -138,6 +142,8 @@ terraformer:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         release:
           nextversion: 'bump_minor'
         slack:
@@ -146,9 +152,23 @@ terraformer:
             internal_scp_workspace:
               channel_name: 'C9CEBQPGE' #sap-tech-gardener
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~
         publish:
           oci-builder: 'docker-buildx'
           dockerimages:
             terraformer:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/terraformer
               tag_as_latest: true
+            terraformer-alicloud:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/terraformer-alicloud
+            terraformer-aws:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/terraformer-aws
+            terraformer-azure:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/terraformer-azure
+            terraformer-gcp:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/terraformer-gcp
+            terraformer-openstack:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/terraformer-openstack
+            terraformer-equinixmetal:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/terraformer-equinixmetal
+            terraformer-slim:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/terraformer-slim

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,7 +7,7 @@ terraformer:
       options:
         public_build_logs: true
       publish:
-        oci-builder: 'kaniko'
+        oci-builder: 'docker-buildx'
         dockerimages:
           terraformer:
             image: 'eu.gcr.io/gardener-project/gardener/terraformer'
@@ -148,7 +148,7 @@ terraformer:
               slack_cfg_name: 'scp_workspace'
         component_descriptor: ~
         publish:
-          oci-builder: 'kaniko'
+          oci-builder: 'docker-buildx'
           dockerimages:
             terraformer:
               tag_as_latest: true

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,7 +1,5 @@
 terraformer:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess: 'inject-commit-hash'
@@ -12,7 +10,6 @@ terraformer:
         oci-builder: 'kaniko'
         dockerimages:
           terraformer:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/terraformer'
             target: terraformer
             resource_labels:
@@ -25,7 +22,6 @@ terraformer:
                 integrity_requirement: 'high'
                 availability_requirement: 'low'
           terraformer-alicloud:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/terraformer-alicloud'
             target: terraformer
             build_args:
@@ -40,7 +36,6 @@ terraformer:
                 integrity_requirement: 'high'
                 availability_requirement: 'low'
           terraformer-aws:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/terraformer-aws'
             target: terraformer
             build_args:
@@ -55,7 +50,6 @@ terraformer:
                 integrity_requirement: 'high'
                 availability_requirement: 'low'
           terraformer-azure:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/terraformer-azure'
             target: terraformer
             build_args:
@@ -70,7 +64,6 @@ terraformer:
                 integrity_requirement: 'high'
                 availability_requirement: 'low'
           terraformer-gcp:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/terraformer-gcp'
             target: terraformer
             build_args:
@@ -85,7 +78,6 @@ terraformer:
                 integrity_requirement: 'high'
                 availability_requirement: 'low'
           terraformer-openstack:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/terraformer-openstack'
             target: terraformer
             build_args:
@@ -100,7 +92,6 @@ terraformer:
                 integrity_requirement: 'high'
                 availability_requirement: 'low'
           terraformer-equinixmetal:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/terraformer-equinixmetal'
             target: terraformer
             build_args:
@@ -115,7 +106,6 @@ terraformer:
                 policy: 'skip'
                 comment: only open source related component
           terraformer-slim:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/terraformer-slim'
             target: terraformer
             build_args:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -134,7 +134,7 @@ terraformer:
           - test-e2e.sh
           trait_depends:
           - publish
-          image: 'eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable'
+          image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/testmachinery-run:stable
       traits:
         version:
           preprocess: 'finalize'

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 NAME                 := terraformer
-IMAGE_REPOSITORY     := eu.gcr.io/gardener-project/gardener/$(NAME)
+IMAGE_REPOSITORY     := europe-docker.pkg.dev/gardener-project/public/gardener/$(NAME)
 IMAGE_REPOSITORY_DEV := $(IMAGE_REPOSITORY)/dev
 REPO_ROOT            := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 VERSION              := $(shell cat "$(REPO_ROOT)/VERSION")

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Running Suite: Terraformer Pod E2E Suite
 ## Docker Images
 
 Terraformer images are built with every pipeline run and pushed to a public GCR repository.
-The list of existing images and tags can be found in [eu.gcr.io/gardener-project/gardener](https://eu.gcr.io/gardener-project/gardener).
+The list of existing images and tags can be found in [europe-docker.pkg.dev/gardener-project/public/gardener](https://europe-docker.pkg.dev/gardener-project/public/gardener).
 
 ### Image variants
 
@@ -173,8 +173,8 @@ With the different image variants, Gardener provider extensions can now deploy t
 plugins inside. Also, the different extensions don't have to agree on a common terraform version, but are able to choose
 the terraform version which they want to use in their provider-specific image.
 
-The `all` image variant is tagged as `eu.gcr.io/gardener-project/gardener/terraformer`, while the provider-specific
-image variants are tagged as `eu.gcr.io/gardener-project/gardener/terraformer-{aws,gcp,...}`.
+The `all` image variant is tagged as `europe-docker.pkg.dev/gardener-project/public/gardener/terraformer`, while the provider-specific
+image variants are tagged as `europe-docker.pkg.dev/gardener-project/public/gardener/terraformer-{aws,gcp,...}`.
 
 ### Building images locally
 

--- a/example/20-terraformer-validate-pod.yaml
+++ b/example/20-terraformer-validate-pod.yaml
@@ -12,7 +12,7 @@ spec:
   activeDeadlineSeconds: 1800
   containers:
   - name: terraform
-    image: eu.gcr.io/gardener-project/gardener/terraformer:v2.6.0
+    image: europe-docker.pkg.dev/gardener-project/public/gardener/terraformer:v2.6.0
     imagePullPolicy: IfNotPresent
     command:
     - /terraformer

--- a/example/30-terraformer-apply-pod.yaml
+++ b/example/30-terraformer-apply-pod.yaml
@@ -12,7 +12,7 @@ spec:
   activeDeadlineSeconds: 1800
   containers:
   - name: terraform
-    image: eu.gcr.io/gardener-project/gardener/terraformer:v2.6.0
+    image: europe-docker.pkg.dev/gardener-project/public/gardener/terraformer:v2.6.0
     imagePullPolicy: IfNotPresent
     command:
     - /terraformer

--- a/example/40-terraformer-destroy-pod.yaml
+++ b/example/40-terraformer-destroy-pod.yaml
@@ -12,7 +12,7 @@ spec:
   activeDeadlineSeconds: 1800
   containers:
   - name: terraform
-    image: eu.gcr.io/gardener-project/gardener/terraformer:v2.6.0
+    image: europe-docker.pkg.dev/gardener-project/public/gardener/terraformer:v2.6.0
     imagePullPolicy: IfNotPresent
     command:
     - /terraformer

--- a/test/e2e/pod/pod_test.go
+++ b/test/e2e/pod/pod_test.go
@@ -39,7 +39,7 @@ const (
 	keyAccessKeyID          = "accessKeyID"
 	keySecretAccessKey      = "secretAccessKey"
 
-	terraformerImage = "eu.gcr.io/gardener-project/gardener/terraformer-aws"
+	terraformerImage = "europe-docker.pkg.dev/gardener-project/public/gardener/terraformer-aws"
 )
 
 var (


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

In addition, switch testmachinery-Image to new location in Artifact-Registry.

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
