### PR TITLE
Update alpine base-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ARG PROVIDER
 RUN make install PROVIDER=$PROVIDER
 
 ############# terraformer
-FROM alpine:3.19.0 AS terraformer
+FROM alpine:3.19.1 AS terraformer
 
 # add additional packages that are required by provider plugins
 RUN apk add --update tzdata


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates Alpine base-image to latest available `3.19`
