### PR TITLE
Add a network connectivity check to make sure pod can reach kubernete…

### DIFF
--- a/cmd/terraformer/main.go
+++ b/cmd/terraformer/main.go
@@ -7,8 +7,10 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
+	"time"
 
 	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -17,7 +19,39 @@ import (
 	"github.com/gardener/terraformer/pkg/utils"
 )
 
+func checkNetworkConnectivity(url string) error {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("unable to reach the server: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Just return nil if the server is reachable, regardless of the status code
+	return nil
+}
+
 func main() {
+	// Check if the KUBERNETES_SERVICE_HOST environment variable is set
+	kubernetesServiceHost := os.Getenv("KUBERNETES_SERVICE_HOST")
+	if kubernetesServiceHost == "" {
+		panic("KUBERNETES_SERVICE_HOST is not set. cannot start terraformer.")
+	}
+
+	// Retry network connectivity check every 5 seconds until successful
+	url := fmt.Sprintf("https://%s", kubernetesServiceHost)
+	for {
+		if err := checkNetworkConnectivity(url); err != nil {
+			fmt.Printf("network connectivity check failed: %v. Retrying in 5 seconds...\n", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		break
+	}
+
 	if err := exec.Command("which", terraformer.TerraformBinary).Run(); err != nil {
 		panic("terraform is not installed or not executable. cannot start terraformer.")
 	}


### PR DESCRIPTION
…s API before executing terraform.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:    control-plane|quality
"/kind" identifiers:     enhancement

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane|quality
/kind enhancement

**What this PR does / why we need it**:  Our Gardener landscape is having trouble with the terraformer pod unable to connect to the Kubernetes API server.  After debugging, it appears the terraformer code runs before pod networking is fully up, resulting in failure of being able to reach kubernetes API.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
- category:      bugfix
- target_group:  operator
```other operator

```
