### PR TITLE
[GEP-26] Update azurerm provider to 3.47.0

### DIFF
--- a/build/all/terraform-bundle.hcl
+++ b/build/all/terraform-bundle.hcl
@@ -8,7 +8,7 @@ terraform {
       version = "4.55.0"
     }
     azurerm = {
-      version = "3.44.0"
+      version = "3.47.0"
     }
     google = {
       version = "4.53.1"

--- a/build/azure/terraform-bundle.hcl
+++ b/build/azure/terraform-bundle.hcl
@@ -5,7 +5,7 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "3.44.0"
+      version = "3.47.0"
     }
     null = {
       version = "3.2.1"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
This PR updates the `azurerm` provider to version 3.47.0. A bug which prevents the `OIDC_TOKEN_FILE_PATH` to be read was introduced in 3.44.0 and fixed in 3.47.0. See https://github.com/hashicorp/terraform-provider-azurerm/issues/20671 for more details.

I have tested creating and deleting a shoot cluster using the [local Gardener with extensions](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally_with_extensions.md) setup.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Part https://github.com/gardener/gardener/issues/9586

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Provider `azurerm` was updated to version 3.47.0 and is now properly recognising the `ARM_OIDC_TOKEN_FILE_PATH` env variable.
```
